### PR TITLE
make rootSelector configurable

### DIFF
--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularBinding.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularBinding.java
@@ -2,7 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 
 public class ByAngularBinding extends ByAngular.BaseBy {
 
@@ -16,7 +15,7 @@ public class ByAngularBinding extends ByAngular.BaseBy {
     protected Object getObject(SearchContext context, JavascriptExecutor javascriptExecutor) {
         return javascriptExecutor.executeScript(
                 "var using = arguments[0] || document;\n" +
-                        "var rootSelector = 'body';\n" +
+                        "var rootSelector = '"+NgWebDriver.rootSelector+"';\n" +
                         "var exactMatch = false;\n" +
                         "var binding = '" + binding + "';\n" +
                         "\n" +

--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularButtonText.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularButtonText.java
@@ -2,10 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-import java.util.List;
 
 public class ByAngularButtonText extends ByAngular.BaseBy {
 

--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularExactBinding.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularExactBinding.java
@@ -2,7 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 
 public class ByAngularExactBinding extends ByAngular.BaseBy {
 
@@ -16,7 +15,7 @@ public class ByAngularExactBinding extends ByAngular.BaseBy {
     protected Object getObject(SearchContext context, JavascriptExecutor javascriptExecutor) {
         return javascriptExecutor.executeScript(
                 "var using = arguments[0] || document;\n" +
-                        "var rootSelector = 'body';\n" +
+                        "var rootSelector = '"+NgWebDriver.rootSelector+"';\n" +
                         "var exactMatch = true;\n" +
                         "var binding = '" + binding + "';\n" +
                         "\n" +

--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularModel.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularModel.java
@@ -2,7 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 
 public class ByAngularModel extends ByAngular.BaseBy {
 
@@ -16,7 +15,7 @@ public class ByAngularModel extends ByAngular.BaseBy {
     protected Object getObject(SearchContext context, JavascriptExecutor javascriptExecutor) {
         return javascriptExecutor.executeScript(
                 "var using = arguments[0] || document;\n" +
-                        "var rootSelector = 'body';\n" +
+                        "var rootSelector = '"+NgWebDriver.rootSelector+"';\n" +
                         "var model = '" + model + "';\n" +
                         "\n" +
                         ByAngular.functions.get("findByModel")

--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularOptions.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularOptions.java
@@ -2,7 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 
 public class ByAngularOptions extends ByAngular.BaseBy {
 

--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularRepeater.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularRepeater.java
@@ -2,7 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 
 public class ByAngularRepeater extends ByAngular.BaseBy {
 
@@ -26,7 +25,7 @@ public class ByAngularRepeater extends ByAngular.BaseBy {
     protected Object getObject(SearchContext context, JavascriptExecutor javascriptExecutor) {
         return javascriptExecutor.executeScript(
                     "var using = arguments[0] || document;\n" +
-                            "var rootSelector = 'body';\n" +
+                            "var rootSelector = '"+NgWebDriver.rootSelector+"';\n" +
                             "var repeater = '" + repeater.replace("'", "\\'") + "';\n" +
                             "var exact = " + exact + ";\n" +
                             "\n" +

--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularRepeaterCell.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularRepeaterCell.java
@@ -2,7 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
@@ -25,7 +24,7 @@ public class ByAngularRepeaterCell extends ByAngular.BaseBy {
     protected Object getObject(SearchContext context, JavascriptExecutor javascriptExecutor) {
         return javascriptExecutor.executeScript(
                     "var using = arguments[0] || document;\n" +
-                            "var rootSelector = 'body';\n" +
+                            "var rootSelector = '"+NgWebDriver.rootSelector+"';\n" +
                             "var repeater = '" + repeater.replace("'", "\\'") + "';\n" +
                             "var index = " + row + ";\n" +
                             "var binding = '" + column + "';\n" +

--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularRepeaterColumn.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularRepeaterColumn.java
@@ -2,7 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 
 public class ByAngularRepeaterColumn extends ByAngular.BaseBy {
 
@@ -24,7 +23,7 @@ public class ByAngularRepeaterColumn extends ByAngular.BaseBy {
     protected Object getObject(SearchContext context, JavascriptExecutor javascriptExecutor) {
         return javascriptExecutor.executeScript(
                     "var using = arguments[0] || document;\n" +
-                            "var rootSelector = 'body';\n" +
+                            "var rootSelector = '"+NgWebDriver.rootSelector+"';\n" +
                             "var repeater = '" + repeater.replace("'", "\\'") + "';\n" +
                             "var binding = '" + column + "';\n" +
                             "var exact = " + exact + ";\n" +

--- a/src/main/java/com/paulhammant/ngwebdriver/ByAngularRepeaterRow.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/ByAngularRepeaterRow.java
@@ -2,7 +2,6 @@ package com.paulhammant.ngwebdriver;
 
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
@@ -27,7 +26,7 @@ public class ByAngularRepeaterRow extends ByAngular.BaseBy {
     protected Object getObject(SearchContext context, JavascriptExecutor javascriptExecutor) {
         return javascriptExecutor.executeScript(
                     "var using = arguments[0] || document;\n" +
-                            "var rootSelector = 'body';\n" +
+                            "var rootSelector = '"+NgWebDriver.rootSelector+"';\n" +
                             "var repeater = '" + repeater.replace("'", "\\'") + "';\n" +
                             "var index = " + row + ";\n" +
                             "var exact = " + exact+ ";\n" +

--- a/src/main/java/com/paulhammant/ngwebdriver/NgWebDriver.java
+++ b/src/main/java/com/paulhammant/ngwebdriver/NgWebDriver.java
@@ -5,6 +5,8 @@ import org.openqa.selenium.WebElement;
 
 public class NgWebDriver {
 
+    public static String rootSelector = "[ng-app]";
+
     private JavascriptExecutor driver;
 
     public NgWebDriver(JavascriptExecutor driver) {
@@ -13,7 +15,8 @@ public class NgWebDriver {
 
     public void mutate(WebElement element, final String variable, final String value) {
         driver.executeScript("angular.element(arguments[0]).scope()." + variable + " = " + value + ";" +
-                "angular.element(document.body).injector().get('$rootScope').$apply();", element);
+                "var root = document.querySelector('" + rootSelector + "');" +
+                "angular.element(root).injector().get('$rootScope').$apply();", element);
     }
 
     public String retrieveJson(WebElement element, final String variable) {
@@ -47,14 +50,14 @@ public class NgWebDriver {
 
     public void waitForAngularRequestsToFinish() {
         driver.executeAsyncScript("var callback = arguments[arguments.length - 1];\n" +
-                "var rootSelector = 'body';\n" +
+                "var rootSelector = '"+rootSelector+"';\n" +
                 "\n" +
                 ByAngular.functions.get("waitForAngular"));
     }
 
     public String getLocationAbsUrl() {
         return (String) driver.executeScript(
-                "var selector = 'body';\n" +
+                "var selector = '"+rootSelector+"';\n" +
                 "\n" +
                 ByAngular.functions.get("getLocationAbsUrl"));
     }


### PR DESCRIPTION
the library is useful for me, but I cannot use it without modifications.

The problem for me is that the root selector is hardcoded as **body**. In my case the ng-app is defined elsewhere in the html. I made some adaptions so that the rootSelector is configurable. Additionally, the default selector ist now **[ng-app]** which should always work as long as there is only one angular app on a page.